### PR TITLE
Improved snapshot diffing for html

### DIFF
--- a/lib/rspec/snapshot/matchers/match_snapshot.rb
+++ b/lib/rspec/snapshot/matchers/match_snapshot.rb
@@ -58,7 +58,7 @@ module RSpec
         private
 
         def actual_formatted
-          RSpec::Support::ObjectFormatter.format(expected)
+          RSpec::Support::ObjectFormatter.format(actual)
         end
 
         def expected_formatted

--- a/lib/rspec/snapshot/matchers/match_snapshot.rb
+++ b/lib/rspec/snapshot/matchers/match_snapshot.rb
@@ -18,7 +18,6 @@ module RSpec
           if File.exist?(snap_path)
             file = File.new(snap_path)
             @expect = file.read
-            @expect = normalize_html(@expect) if @snapshot_name.include? 'html'
             file.close
             @actual == @expect
           else

--- a/lib/rspec/snapshot/matchers/match_snapshot.rb
+++ b/lib/rspec/snapshot/matchers/match_snapshot.rb
@@ -14,12 +14,11 @@ module RSpec
           filename = "#{@snapshot_name}.snap"
           snap_path = File.join(snapshot_dir, filename)
           FileUtils.mkdir_p(File.dirname(snap_path)) unless Dir.exist?(File.dirname(snap_path))
+          @actual = normalize_html(@actual) if @snapshot_name.include? 'html'
           if File.exist?(snap_path)
             file = File.new(snap_path)
             @expect = file.read
-            if @snapshot_name.include? 'html'
-              normalize_html
-            end
+            @expect = normalize_html(@expect) if @snapshot_name.include? 'html'
             file.close
             @actual == @expect
           else
@@ -65,12 +64,12 @@ module RSpec
           RSpec::Support::ObjectFormatter.format(expected)
         end
 
-        def normalize_html
+        def normalize_html(value)
           require 'nokogiri'
-          @expect = Nokogiri::HTML(@expect, &:noblanks).to_xhtml(indent: 2)
-          @actual = Nokogiri::HTML(@actual, &:noblanks).to_xhtml(indent: 2)
+          Nokogiri::HTML(value, &:noblanks).to_xhtml(indent: 2)
         rescue LoadError
           puts 'Add nokogiri gem for improved HTML snapshot diffing.'
+          value
         end
       end
     end

--- a/rspec-snapshot.gemspec
+++ b/rspec-snapshot.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry", "~> 0.10.4"
   spec.add_development_dependency "activesupport", "~> 5.0.0"
+  spec.add_development_dependency "nokogiri"
 end

--- a/spec/fixtures/snapshots/snapshot/html.snap
+++ b/spec/fixtures/snapshots/snapshot/html.snap
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title></title>
-</head>
-<body>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta charset="UTF-8" />
+    <title></title>
+  </head>
+  <body>
   <h1>rspec-snapshot</h1>
   <p>
     Snapshot is awesome!

--- a/spec/fixtures/snapshots/snapshot/html_no_whitespace.snap
+++ b/spec/fixtures/snapshots/snapshot/html_no_whitespace.snap
@@ -1,1 +1,12 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title></title></head><body><h1>rspec-snapshot</h1><p>Snapshot is awesome!</p></body></html>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta charset="UTF-8" />
+    <title></title>
+  </head>
+  <body>
+    <h1>rspec-snapshot</h1>
+    <p>Snapshot is awesome!</p>
+  </body>
+</html>

--- a/spec/fixtures/snapshots/snapshot/html_no_whitespace.snap
+++ b/spec/fixtures/snapshots/snapshot/html_no_whitespace.snap
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title></title></head><body><h1>rspec-snapshot</h1><p>Snapshot is awesome!</p></body></html>

--- a/spec/rspec/snapshot/matchers_spec.rb
+++ b/spec/rspec/snapshot/matchers_spec.rb
@@ -9,7 +9,7 @@ describe RSpec::Snapshot::Matchers do
     expect(json).to match_snapshot("snapshot/json")
   end
 
-  it "snapshot html" do
+  it "matches html" do
     html = <<-HTML.strip_heredoc
     <!DOCTYPE html>
     <html lang="en">
@@ -27,5 +27,65 @@ describe RSpec::Snapshot::Matchers do
     HTML
 
     expect(html).to match_snapshot("snapshot/html")
+  end
+
+  describe "html diffing" do
+    shared_examples_for "a proper html diff missing h1 tag" do
+      it "outputs a diff" do
+        expect do
+          expect(wrong_html).to match_snapshot(snapshot)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /Diff:/)
+      end
+
+      it "flags the h1 as missing" do
+        expect do
+          expect(wrong_html).to match_snapshot(snapshot)
+        end.to raise_error do |exception|
+          expect(exception.message).to match %r{\-\s+<h1>rspec-snapshot</h1>}
+        end
+      end
+    end
+
+    context "with whitespace between elements" do
+      let(:snapshot) { "snapshot/html" }
+      let(:wrong_html) do
+        <<-HTML.strip_heredoc
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <title></title>
+        </head>
+        <body>
+          <p>
+            Snapshot is awesome!
+          </p>
+        </body>
+        </html>
+        HTML
+      end
+
+      it_behaves_like "a proper html diff missing h1 tag"
+    end
+
+    context "with no whitespace between elements" do
+      let(:snapshot) { "snapshot/html_no_whitespace" }
+      let(:wrong_html) do
+        <<-HTML.strip_heredoc
+        <!DOCTYPE html>
+        <html lang="en"><head><meta charset="UTF-8"><title></title></head><body><p>Snapshot is awesome!</p></body></html>
+        HTML
+      end
+
+      it_behaves_like "a proper html diff missing h1 tag"
+
+      it "does not flag the body as removed" do
+        expect do
+          expect(wrong_html).to match_snapshot(snapshot)
+        end.to raise_error do |exception|
+          expect(exception.message).to_not match /\-\s*<body>/
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
First of all thanks for creating this 👍

I noticed two minor issues when started using this gem:

1. The `failure_reason` has a typo, so the actual and expected values are not printed.
2. Diffing compact HTML is hard

This PR aims to fix these two issues.

By including `html` in the snapshot name, the actual and expected values will be parsed by Nokogiri and outputted in a consistent format (with consistent indentation). This has proven to be very valuable for us when testing views.

Screenshot of an example diff:

<img width="968" alt="screen shot 2017-01-03 at 13 54 38" src="https://cloud.githubusercontent.com/assets/874365/21608364/5b9efbca-d1bc-11e6-8297-15a7ed956164.png">
