### PR TITLE
Use the diffable feature from RSpec expectations

### DIFF
--- a/lib/rspec/snapshot/matchers/match_snapshot.rb
+++ b/lib/rspec/snapshot/matchers/match_snapshot.rb
@@ -4,6 +4,8 @@ module RSpec
   module Snapshot
     module Matchers
       class MatchSnapShot
+        attr_reader :actual, :expected
+
         def initialize(metadata, snapshot_name)
           @metadata = metadata
           @snapshot_name = snapshot_name
@@ -16,9 +18,9 @@ module RSpec
           FileUtils.mkdir_p(File.dirname(snap_path)) unless Dir.exist?(File.dirname(snap_path))
           if File.exist?(snap_path)
             file = File.new(snap_path)
-            @expect = file.read
+            @expected = file.read
             file.close
-            @actual.to_s == @expect
+            @actual.to_s == @expected
           else
             RSpec.configuration.reporter.message "Generate #{snap_path}"
             file = File.new(snap_path, "w+")
@@ -28,9 +30,12 @@ module RSpec
           end
         end
 
+        def diffable?
+          true
+        end
 
         def failure_message
-          "\nexpected: #{@expect}\n     got: #{@actual}\n"
+          "\nexpected: #{@expected}\n     got: #{@actual}\n"
         end
 
         def snapshot_dir


### PR DESCRIPTION
Related to: https://github.com/yesmeck/rspec-snapshot/pull/7

This PR enables diffing on the MatchSnapshot matcher described in https://relishapp.com/rspec/rspec-expectations/docs/diffing

You can see how the `diffable?` method is being used here: https://github.com/rspec/rspec-expectations/blob/add9b271ecb1d65f7da5bc8a9dd8c64d81d92303/lib/rspec/expectations/handler.rb#L38

Result:

![image](https://user-images.githubusercontent.com/4183514/42355155-27282e5e-8091-11e8-8c8b-748e70e87a9b.png)

